### PR TITLE
[Broadcaster] Move to the VP8

### DIFF
--- a/broadcaster/lib/broadcaster/peer_supervisor.ex
+++ b/broadcaster/lib/broadcaster/peer_supervisor.ex
@@ -17,7 +17,7 @@ defmodule Broadcaster.PeerSupervisor do
   @video_codecs [
     %RTPCodecParameters{
       payload_type: 96,
-      mime_type: "video/H264",
+      mime_type: "video/VP8",
       clock_rate: 90_000
     }
   ]


### PR DESCRIPTION
Depending on the OS and web browser, H264 might not be available. Hence, VP8 which is royalty-free and should always be available