### PR TITLE
[All] Fix "assets formatting" check in CI

### DIFF
--- a/.github/workflows/__CI__build-check-app.yml
+++ b/.github/workflows/__CI__build-check-app.yml
@@ -108,9 +108,4 @@ jobs:
 
     - name: Check assets formatting
       if: ${{ !cancelled() }}
-      run: |
-        mix assets.format
-        if [[ -n "$(git status --porcelain)" ]]; then
-          echo "Assets formatter introduced changes. Run `mix assets.format` and commit the updated files"
-          exit 1
-        fi
+      run: mix assets.check

--- a/broadcaster/assets/package.json
+++ b/broadcaster/assets/package.json
@@ -5,7 +5,8 @@
   "main": "",
   "scripts": {
     "lint": "eslint 'js/**/*.js' --fix",
-    "format": "prettier --write 'js/**/*.js' 'css/**/*.css'"
+    "format": "prettier --write 'js/**/*.js' 'css/**/*.css'",
+    "check": "prettier --check 'js/**/*.js' 'css/**/*.css'"
   },
   "keywords": [],
   "author": "",

--- a/broadcaster/mix.exs
+++ b/broadcaster/mix.exs
@@ -83,7 +83,8 @@ defmodule Broadcaster.MixProject do
         "esbuild broadcaster --minify",
         "phx.digest"
       ],
-      "assets.format": &lint_and_format_assets/1
+      "assets.format": &lint_and_format_assets/1,
+      "assets.check": &check_assets/1
     ]
   end
 
@@ -91,6 +92,17 @@ defmodule Broadcaster.MixProject do
     with {_, 0} <- execute_npm_command(["ci"]),
          {_, 0} <- execute_npm_command(["run", "lint"]),
          {_, 0} <- execute_npm_command(["run", "format"]) do
+      :ok
+    else
+      {cmd, rc} ->
+        Mix.shell().error("npm command `#{Enum.join(cmd, " ")}` failed with code #{rc}")
+        exit({:shutdown, rc})
+    end
+  end
+
+  defp check_assets(_args) do
+    with {_, 0} <- execute_npm_command(["ci"]),
+         {_, 0} <- execute_npm_command(["run", "check"]) do
       :ok
     else
       {cmd, rc} ->

--- a/nexus/assets/package.json
+++ b/nexus/assets/package.json
@@ -5,7 +5,8 @@
   "main": "",
   "scripts": {
     "lint": "eslint 'js/**/*.js' --fix",
-    "format": "prettier --write 'js/**/*.js' 'css/**/*.css'"
+    "format": "prettier --write 'js/**/*.js' 'css/**/*.css'",
+    "check": "prettier --check 'js/**/*.js' 'css/**/*.css'"
   },
   "keywords": [],
   "author": "",

--- a/nexus/mix.exs
+++ b/nexus/mix.exs
@@ -73,7 +73,8 @@ defmodule Nexus.MixProject do
         "esbuild nexus --minify",
         "phx.digest"
       ],
-      "assets.format": &lint_and_format_assets/1
+      "assets.format": &lint_and_format_assets/1,
+      "assets.check": &check_assets/1
     ]
   end
 
@@ -81,6 +82,17 @@ defmodule Nexus.MixProject do
     with {_, 0} <- execute_npm_command(["ci"]),
          {_, 0} <- execute_npm_command(["run", "lint"]),
          {_, 0} <- execute_npm_command(["run", "format"]) do
+      :ok
+    else
+      {cmd, rc} ->
+        Mix.shell().error("npm command `#{Enum.join(cmd, " ")}` failed with code #{rc}")
+        exit({:shutdown, rc})
+    end
+  end
+
+  defp check_assets(_args) do
+    with {_, 0} <- execute_npm_command(["ci"]),
+         {_, 0} <- execute_npm_command(["run", "check"]) do
       :ok
     else
       {cmd, rc} ->

--- a/recognizer/assets/package.json
+++ b/recognizer/assets/package.json
@@ -5,7 +5,8 @@
   "main": "",
   "scripts": {
     "lint": "eslint 'js/**/*.js' --fix",
-    "format": "prettier --write 'js/**/*.js' 'css/**/*.css'"
+    "format": "prettier --write 'js/**/*.js' 'css/**/*.css'",
+    "check": "prettier --check 'js/**/*.js' 'css/**/*.css'"
   },
   "keywords": [],
   "author": "",

--- a/recognizer/mix.exs
+++ b/recognizer/mix.exs
@@ -76,7 +76,8 @@ defmodule Recognizer.MixProject do
       "assets.setup": ["tailwind.install --if-missing", "esbuild.install --if-missing"],
       "assets.build": ["tailwind default", "esbuild default"],
       "assets.deploy": ["tailwind default --minify", "esbuild default --minify", "phx.digest"],
-      "assets.format": &lint_and_format_assets/1
+      "assets.format": &lint_and_format_assets/1,
+      "assets.check": &check_assets/1
     ]
   end
 
@@ -84,6 +85,17 @@ defmodule Recognizer.MixProject do
     with {_, 0} <- execute_npm_command(["ci"]),
          {_, 0} <- execute_npm_command(["run", "lint"]),
          {_, 0} <- execute_npm_command(["run", "format"]) do
+      :ok
+    else
+      {cmd, rc} ->
+        Mix.shell().error("npm command `#{Enum.join(cmd, " ")}` failed with code #{rc}")
+        exit({:shutdown, rc})
+    end
+  end
+
+  defp check_assets(_args) do
+    with {_, 0} <- execute_npm_command(["ci"]),
+         {_, 0} <- execute_npm_command(["run", "check"]) do
       :ok
     else
       {cmd, rc} ->


### PR DESCRIPTION
Currently, the check relies on `git status`, which leads to many problems, when other files (like `mix.lock`) are changed throughout the workflow