### PR TITLE
[Broadcaster] Don't drop the connection on ICE candidate gathering timeout

### DIFF
--- a/broadcaster/lib/broadcaster/peer_supervisor.ex
+++ b/broadcaster/lib/broadcaster/peer_supervisor.ex
@@ -119,7 +119,7 @@ defmodule Broadcaster.PeerSupervisor do
     receive do
       {:ex_webrtc, ^pc, {:ice_gathering_state_change, :complete}} -> :ok
     after
-      1000 -> {:error, :timeout}
+      1000 -> :ok
     end
   end
 

--- a/broadcaster/lib/broadcaster/peer_supervisor.ex
+++ b/broadcaster/lib/broadcaster/peer_supervisor.ex
@@ -116,6 +116,8 @@ defmodule Broadcaster.PeerSupervisor do
   end
 
   defp gather_candidates(pc) do
+    # we either wait for all of the candidates
+    # or whatever we were able to gather in one second
     receive do
       {:ex_webrtc, ^pc, {:ice_gathering_state_change, :complete}} -> :ok
     after


### PR DESCRIPTION
Now, if the process of ICE candidate gathering times out, we throw an error. Instead, we should just send the description with whatever candidates we were able to gather up until the timeout occurred.