### PR TITLE
[Broadcaster] Preserve chat history

### DIFF
--- a/broadcaster/lib/broadcaster/application.ex
+++ b/broadcaster/lib/broadcaster/application.ex
@@ -23,6 +23,7 @@ defmodule Broadcaster.Application do
       BroadcasterWeb.Presence,
       Broadcaster.PeerSupervisor,
       Broadcaster.Forwarder,
+      Broadcaster.ChatHistory,
       {Registry, name: Broadcaster.PeerRegistry, keys: :unique},
       {Registry, name: Broadcaster.ChatNicknamesRegistry, keys: :unique}
     ]

--- a/broadcaster/lib/broadcaster/chat_history.ex
+++ b/broadcaster/lib/broadcaster/chat_history.ex
@@ -1,0 +1,42 @@
+defmodule Broadcaster.ChatHistory do
+  @moduledoc false
+  use Agent
+
+  @max_history_size 100
+
+  @spec start_link(term()) :: Agent.on_start()
+  def start_link(_) do
+    Agent.start_link(fn -> %{size: 0, queue: :queue.new()} end, name: __MODULE__)
+  end
+
+  @spec put(map()) :: :ok
+  def put(msg) do
+    Agent.cast(__MODULE__, fn history ->
+      queue = :queue.in(msg, history.queue)
+
+      if history.size == @max_history_size do
+        {_, queue} = :queue.out(history.queue)
+        %{history | queue: queue}
+      else
+        %{history | size: history.size + 1, queue: queue}
+      end
+    end)
+  end
+
+  @spec get() :: [map()]
+  def get() do
+    try do
+      Agent.get(__MODULE__, fn history -> :queue.to_list(history.queue) end, 1000)
+    catch
+      :exit, _ -> []
+    end
+  end
+
+  @spec delete(String.t()) :: :ok
+  def delete(id) do
+    Agent.update(__MODULE__, fn history ->
+      queue = :queue.delete_with(fn msg -> msg.id == id end, history.queue)
+      %{history | size: history.size - 1, queue: queue}
+    end)
+  end
+end

--- a/broadcaster/lib/broadcaster_web/channels/stream_channel.ex
+++ b/broadcaster/lib/broadcaster_web/channels/stream_channel.ex
@@ -29,6 +29,7 @@ defmodule BroadcasterWeb.StreamChannel do
       id: "#{socket.assigns.user_id}:#{socket.assigns.msg_count}"
     }
 
+    Broadcaster.ChatHistory.put(msg)
     broadcast!(socket, "chat_msg", msg)
 
     {:noreply, assign(socket, :msg_count, socket.assigns.msg_count + 1)}
@@ -56,6 +57,10 @@ defmodule BroadcasterWeb.StreamChannel do
   def handle_info(:after_join, socket) do
     {:ok, _} = Presence.track(socket, socket.assigns.user_id, %{})
     push(socket, "presence_state", Presence.list(socket))
+
+    Broadcaster.ChatHistory.get()
+    |> Enum.each(fn msg -> :ok = push(socket, "chat_msg", msg) end)
+
     {:noreply, socket}
   end
 

--- a/broadcaster/lib/broadcaster_web/controllers/page_controller.ex
+++ b/broadcaster/lib/broadcaster_web/controllers/page_controller.ex
@@ -17,6 +17,7 @@ defmodule BroadcasterWeb.PageController do
   end
 
   def delete_chat_message(conn, %{"id" => id}) do
+    Broadcaster.ChatHistory.delete(id)
     BroadcasterWeb.Endpoint.broadcast!("stream:chat", "delete_chat_msg", %{id: id})
     send_resp(conn, 200, "")
   end


### PR DESCRIPTION
This is a very simple implementation of chat history. It has a couple of drawbacks:
* it's not resilient for very very high loads - in such case, messages will accumulate in Agent's queue and they will block `get` requests 
* I am not sure but I think there is no guarantee that the order of messages in the history will be the same as the order seen in real-time. E.g. we have two processes A and B, A receives a message from the client side, B receives a message from the client side, A saves to the history, B saves to the history, then I believe, for some reasons B can broadcast its message to other processes before A will do this. 

I think that we don't have to worry about the first one until we notice this is a problem. I added a simple try catch not to break the whole chat.

The second one sounds a bit unlikely. To solve it, we would probable have to record time of message receival and reorder messages on the frontend (if needed). 